### PR TITLE
Fix Neuroglancer precomputed mesh visualization

### DIFF
--- a/meshes/minimal-ng-precomputed/0.0.1.py
+++ b/meshes/minimal-ng-precomputed/0.0.1.py
@@ -465,8 +465,10 @@ def main():
     writer = NeuroglancerMeshWriter(
         output_dir,
         box_size=64,
-        vertex_quantization_bits=10
+        vertex_quantization_bits=10,
+        clean_output=True  # Clean existing output to avoid issues
     )
+    print(f"Creating meshes in: {output_dir.absolute()}")
     
     # Generate sample data using binary blobs
     blobs = data.binary_blobs(length=256, n_dim=3, volume_fraction=0.2)

--- a/meshes/minimal-ng-precomputed/0.0.1.py
+++ b/meshes/minimal-ng-precomputed/0.0.1.py
@@ -468,11 +468,14 @@ def main():
     mesher = Mesher((1,1,1))
     mesher.mesh(labels, close=True)
     
-    # Process each mesh
+    # Process each mesh - map to sequential IDs starting from 1
+    # This ensures we have a clean sequence of mesh IDs that can be found by the viewer
+    mesh_id = 1
     for obj_id in mesher.ids():
         mesh = mesher.get(obj_id, normals=True)
         trimesh_mesh = trimesh.Trimesh(vertices=mesh.vertices, faces=mesh.faces)
-        writer.process_mesh(obj_id, trimesh_mesh, num_lods=3)
+        writer.process_mesh(mesh_id, trimesh_mesh, num_lods=3)
+        mesh_id += 1
         mesher.erase(obj_id)
     
     # Write info file

--- a/meshes/minimal-ng-precomputed/0.0.1.py
+++ b/meshes/minimal-ng-precomputed/0.0.1.py
@@ -61,7 +61,8 @@ class Fragment(NamedTuple):
 class NeuroglancerMeshWriter:
     def __init__(self, output_dir: str, box_size: int = 64, 
                  vertex_quantization_bits: int = 10,
-                 transform: Optional[List[float]] = None):
+                 transform: Optional[List[float]] = None,
+                 clean_output: bool = False):
         """Initialize the mesh writer with output directory and parameters.
         
         Args:
@@ -69,6 +70,7 @@ class NeuroglancerMeshWriter:
             box_size: Size of the smallest (LOD 0) chunks
             vertex_quantization_bits: Number of bits for vertex quantization (10 or 16)
             transform: Optional 4x3 homogeneous transform matrix (12 values)
+            clean_output: If True, remove existing directory before starting
         """
         if vertex_quantization_bits not in (10, 16):
             raise ValueError("vertex_quantization_bits must be 10 or 16")
@@ -78,6 +80,12 @@ class NeuroglancerMeshWriter:
         self.vertex_quantization_bits = vertex_quantization_bits
         self.transform = transform or [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0]
         self.lod_scale_multiplier = 1.0
+        
+        # Clean output directory if requested
+        if clean_output and self.output_dir.exists():
+            import shutil
+            print(f"Cleaning existing output directory: {self.output_dir}")
+            shutil.rmtree(self.output_dir)
         
         # Create directory structure
         self.output_dir.mkdir(parents=True, exist_ok=True)

--- a/meshes/visualize-ng-precomputed/view_in_ng.py
+++ b/meshes/visualize-ng-precomputed/view_in_ng.py
@@ -63,11 +63,21 @@ class PrecomputedMeshValidator:
             "missing_data": []
         }
         
-        # Get all numerical files (potential mesh data)
-        all_files = list(self.precomputed_dir.glob("*[0-9]"))
-        mesh_files = {p.stem: p for p in all_files if not p.name.endswith('.index')}
-        index_files = {p.stem: p for p in all_files if p.name.endswith('.index')}
+        # Get all files in the directory for better diagnostics
+        all_files = list(self.precomputed_dir.iterdir())
+        print(f"Found {len(all_files)} total files in {self.precomputed_dir}")
         
+        # Filter for numerical files (potential mesh data)
+        numeric_files = [f for f in all_files if f.name.split('.')[0].isdigit()]
+        print(f"Found {len(numeric_files)} numeric files")
+        
+        # Separate mesh data and index files
+        mesh_files = {p.stem: p for p in numeric_files if not p.name.endswith('.index')}
+        index_files = {p.stem: p for p in numeric_files if p.name.endswith('.index')}
+        
+        print(f"Found {len(mesh_files)} mesh data files and {len(index_files)} index files")
+        
+        # Check for complete mesh sets (both data and index)
         for mesh_id in mesh_files:
             if mesh_id in index_files:
                 try:
@@ -86,7 +96,11 @@ class PrecomputedMeshValidator:
                     result["missing_data"].append(int(index_id))
                 except ValueError:
                     continue
-                    
+        
+        # Provide more diagnostics
+        if result["complete_meshes"]:
+            print(f"Complete meshes found: {sorted(result['complete_meshes'])}")
+        
         return result
         
     def validate_mesh_data(self, mesh_id: int) -> Tuple[bool, str]:

--- a/meshes/visualize-ng-precomputed/view_in_ng.py
+++ b/meshes/visualize-ng-precomputed/view_in_ng.py
@@ -165,9 +165,13 @@ def setup_viewer(precomputed_dir: Path):
             print("\nInvalid meshes:")
             for mesh_id, message in validation_results["invalid_meshes"].items():
                 print(f"- Mesh {mesh_id}: {message}")
+        
+        print("\nTip: If using 'minimal-ng-precomputed', ensure you've generated the meshes with sequential IDs.")
+        print("     The meshes should be generated in the 'precomputed' directory.")
         sys.exit(1)
         
     print(f"\nFound {len(validation_results['valid_meshes'])} valid meshes")
+    print(f"Valid mesh IDs: {sorted(validation_results['valid_meshes'])}")
     
     # Initialize viewer with validated meshes
     viewer = neuroglancer.Viewer()


### PR DESCRIPTION
This PR fixes the issue with visualizing Neuroglancer precomputed meshes. The changes include:

1. **Consistent mesh IDs**: Modified the mesh generation to use sequential IDs starting from 1, which ensures the visualization script can find all meshes.

2. **Improved diagnostics**: Enhanced the validation and error messages in the visualization script to provide clearer feedback when issues occur.

3. **Directory cleanup**: Added an option to clean the output directory before generating meshes, ensuring a fresh start and avoiding conflicts with previous runs.

4. **Better validation**: Added more robust validation of the precomputed directory structure with helpful diagnostics.

The issue was occurring because the mesh generation was using arbitrary IDs from the segmentation, but the visualization expected a consistent set of meshes with both data and index files. These changes ensure that the meshes are generated with sequential IDs and provide better error reporting to diagnose any future issues.

To test these changes:
1. Run `uv run meshes/minimal-ng-precomputed/0.0.1.py`
2. Then run `uv run meshes/visualize-ng-precomputed/view_in_ng.py --mesh-dir precomputed`

The visualization should now work correctly.