### PR TITLE
Fix napari precomputed mesh viewer implementation

### DIFF
--- a/meshes/visualize-ng-precomputed/view_in_napari.py
+++ b/meshes/visualize-ng-precomputed/view_in_napari.py
@@ -257,8 +257,7 @@ def main():
             mesh_colors[mesh_id] = (
                 color_seed[0] / 255, 
                 color_seed[1] / 255, 
-                color_seed[2] / 255, 
-                0.7  # Alpha
+                color_seed[2] / 255
             )
             
             # Read the manifest
@@ -286,11 +285,18 @@ def main():
                 )
                 
                 # Add as shapes layer (box outlines)
+                lines = []
+                for i in range(len(edges)):
+                    lines.append(np.array([vertices[edges[i, 0]], vertices[edges[i, 1]]]))
+                
+                # Convert color tuple to string format '#RRGGBB'
+                color_hex = f'#{int(mesh_colors[mesh_id][0]*255):02x}{int(mesh_colors[mesh_id][1]*255):02x}{int(mesh_colors[mesh_id][2]*255):02x}'
+                
                 viewer.add_shapes(
-                    np.column_stack([vertices[edges[:, 0]], vertices[edges[:, 1]]]),
+                    lines,
                     shape_type='line',
                     edge_width=2,
-                    edge_color=mesh_colors[mesh_id],
+                    edge_color=color_hex,
                     name=f"Mesh {mesh_id} - LOD {lod}"
                 )
         


### PR DESCRIPTION
This PR fixes two implementation issues with the napari-based precomputed mesh viewer:

1. **Fixed shape format**: The previous version was passing an improperly formatted array to `viewer.add_shapes()`, resulting in a "Data shape does not match a line" error. This PR fixes it by creating a proper list of line segments.

2. **Fixed color format**: The previous implementation was using RGB tuples for colors, which napari doesn't accept for `edge_color`. This PR converts the color to a hex string (e.g., '#FF0000') which is properly handled by napari.

These changes allow the viewer to properly display the precomputed mesh data with each LOD level as a separate layer, as originally intended.