### PR TITLE
Add aligned and separated viewing modes for LOD inspection

### DIFF
--- a/meshes/visualize-ng-precomputed/view_all_lods.py
+++ b/meshes/visualize-ng-precomputed/view_all_lods.py
@@ -120,8 +120,14 @@ def main():
                                             lod * args.position_offset])
                     mesh.vertices = mesh.vertices + offset_vector
                 
-                # Create a unique name for this layer
-                layer_name = f"Mesh {mesh_id} - LOD {lod}"
+    # Add a helpful indicator to the layer name to show LOD level
+    prefix_by_lod = {
+        0: "🔴 LOD0", 
+        1: "🟢 LOD1", 
+        2: "🔵 LOD2"
+    }
+    prefix = prefix_by_lod.get(lod, f"LOD{lod}")
+    layer_name = f"{prefix}: Mesh {mesh_id}"
                 
                 # Choose color based on LOD level or mesh ID
                 if args.color_by_lod:

--- a/meshes/visualize-ng-precomputed/view_all_lods.py
+++ b/meshes/visualize-ng-precomputed/view_all_lods.py
@@ -45,8 +45,10 @@ def main():
                       help="Color meshes by LOD level (default: True)")
     parser.add_argument("--opacity", type=float, default=0.5,
                       help="Opacity for meshes (default: 0.5)")
+    parser.add_argument("--view-mode", type=str, choices=["aligned", "separated"], default="aligned",
+                      help="View mode: 'aligned' for perfectly aligned LODs, 'separated' for spatially separated LODs (default: aligned)")
     parser.add_argument("--position-offset", type=float, default=10.0,
-                      help="Position offset between LOD levels in visualization (default: 10.0)")
+                      help="Position offset between LOD levels in 'separated' mode (default: 10.0)")
     
     args = parser.parse_args()
     
@@ -111,8 +113,8 @@ def main():
                     print(f"Could not load mesh {mesh_id} at LOD {lod}")
                     continue
                 
-                # Apply offset based on LOD level
-                if args.position_offset != 0:
+                # Apply offset based on LOD level if in separated mode
+                if args.view_mode == "separated" and args.position_offset != 0:
                     offset_vector = np.array([lod * args.position_offset, 
                                             lod * args.position_offset, 
                                             lod * args.position_offset])
@@ -175,18 +177,17 @@ def main():
     # Reset view to show all objects
     viewer.reset_view()
     
-    print("\nNapari viewer launched with all LOD levels.")
+    print(f"\nNapari viewer launched with all LOD levels in '{args.view_mode}' mode.")
     print("LOD visualization colors:")
     print("- LOD 0 (highest detail): Red")
     print("- LOD 1 (medium detail): Green") 
     print("- LOD 2 (lowest detail): Blue")
-    print("\nControls:")
-    print("- Right-click and drag to rotate")
-    print("- Middle-click to pan")
-    print("- Scroll to zoom")
     
-    if args.position_offset != 0:
-        print(f"\nNOTE: LOD levels are offset from each other by {args.position_offset} units for better visualization")
+    if args.view_mode == "aligned":
+        print("\nMeshes are perfectly aligned to verify LOD quality.")
+        print("You can toggle visibility of different LOD levels using the layer list on the left.")
+    elif args.view_mode == "separated" and args.position_offset != 0:
+        print(f"\nNOTE: LOD levels are offset by {args.position_offset} units for easier visual inspection.")
     
     # Start the napari event loop
     napari.run()

--- a/meshes/visualize-ng-precomputed/view_lod_in_napari.py
+++ b/meshes/visualize-ng-precomputed/view_lod_in_napari.py
@@ -67,12 +67,13 @@ def main():
     print(" 1: Medium detail (LOD 1)")
     print(" 2: Lowest detail (LOD 2)")
     print(" a: View all mesh LODs together (one per mesh)")
-    print(" s: Show all LOD levels simultaneously (color-coded)")
+    print(" s1: Show all LOD levels simultaneously (aligned)")
+    print(" s2: Show all LOD levels simultaneously (separated)")
     
-    choice = input("\nEnter your choice (0/1/2/a/s): ").strip().lower()
+    choice = input("\nEnter your choice (0/1/2/a/s1/s2): ").strip().lower()
     
     # Prepare command
-    if choice == "s":
+    if choice in ["s1", "s2"]:
         # Use the special view_all_lods script
         view_script = script_dir / "view_all_lods.py"
         if not view_script.exists():
@@ -80,8 +81,16 @@ def main():
             sys.exit(1)
             
         cmd = [sys.executable, str(view_script), "--mesh-dir", str(mesh_dir)]
-        print("\nLaunching napari viewer with all LOD levels simultaneously...")
-        print("(LODs will be shown color-coded: LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)")
+        
+        # Set view mode based on choice
+        if choice == "s1":
+            cmd.extend(["--view-mode", "aligned"])
+            print("\nLaunching napari viewer with all LOD levels aligned...")
+            print("(LODs will be shown color-coded: LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)")
+        else:  # s2
+            cmd.extend(["--view-mode", "separated"])
+            print("\nLaunching napari viewer with all LOD levels spatially separated...")
+            print("(LODs will be shown color-coded: LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)")
     else:
         # Use the regular view_in_napari script
         cmd = [sys.executable, str(view_script), "--mesh-dir", str(mesh_dir)]


### PR DESCRIPTION
## Summary

This PR enhances the LOD visualization tools to provide both aligned and separated viewing modes, making it easier to properly inspect LOD levels.

## Changes

1. **Added two distinct viewing modes to `view_all_lods.py`**:
   - **Aligned Mode** (default): All LOD levels are perfectly aligned in the same space for direct comparison
   - **Separated Mode**: LOD levels are spatially offset for easier individual inspection

2. **Updated the selection menu in `view_lod_in_napari.py`**:
   - Added options `s1` for aligned view and `s2` for separated view
   - Improved descriptive text for clearer understanding of options

3. **Enhanced the UI experience**:
   - Added colored emoji indicators to layer names (🔴 LOD0, 🟢 LOD1, 🔵 LOD2)
   - Improved console output with helpful instructions

## Benefits

- The aligned mode allows for precise verification that LOD levels are properly aligned in space
- The separated mode makes it easier to visually inspect each LOD level individually
- Color coding and emoji indicators make it easy to identify which LOD level is which
- Better user experience with more options and clearer instructions

## Usage

Run the selection utility:
```bash
uv run meshes/visualize-ng-precomputed/view_lod_in_napari.py --mesh-dir precomputed
```

And select:
- `s1` for aligned view (meshes perfectly aligned)
- `s2` for separated view (meshes offset in space)

Or run directly:
```bash
# Aligned mode (default)
uv run meshes/visualize-ng-precomputed/view_all_lods.py --mesh-dir precomputed --view-mode aligned

# Separated mode
uv run meshes/visualize-ng-precomputed/view_all_lods.py --mesh-dir precomputed --view-mode separated
```