### PR TITLE
Simplify LOD visualization: Show all LODs aligned by default

### DIFF
--- a/meshes/visualize-ng-precomputed/view_lod_in_napari.py
+++ b/meshes/visualize-ng-precomputed/view_lod_in_napari.py
@@ -67,30 +67,21 @@ def main():
     print(" 1: Medium detail (LOD 1)")
     print(" 2: Lowest detail (LOD 2)")
     print(" a: View all mesh LODs together (one per mesh)")
-    print(" s1: Show all LOD levels simultaneously (aligned)")
-    print(" s2: Show all LOD levels simultaneously (separated)")
+    print(" s: Show all LOD levels simultaneously")
     
-    choice = input("\nEnter your choice (0/1/2/a/s1/s2): ").strip().lower()
+    choice = input("\nEnter your choice (0/1/2/a/s): ").strip().lower()
     
     # Prepare command
-    if choice in ["s1", "s2"]:
-        # Use the special view_all_lods script
+    if choice == "s":
+        # Use the view_all_lods script
         view_script = script_dir / "view_all_lods.py"
         if not view_script.exists():
             print(f"Error: Cannot find the all-LODs viewer script at {view_script}")
             sys.exit(1)
             
         cmd = [sys.executable, str(view_script), "--mesh-dir", str(mesh_dir)]
-        
-        # Set view mode based on choice
-        if choice == "s1":
-            cmd.extend(["--view-mode", "aligned"])
-            print("\nLaunching napari viewer with all LOD levels aligned...")
-            print("(LODs will be shown color-coded: LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)")
-        else:  # s2
-            cmd.extend(["--view-mode", "separated"])
-            print("\nLaunching napari viewer with all LOD levels spatially separated...")
-            print("(LODs will be shown color-coded: LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)")
+        print("\nLaunching napari viewer with all LOD levels...")
+        print("(LODs will be shown color-coded: LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)")
     else:
         # Use the regular view_in_napari script
         cmd = [sys.executable, str(view_script), "--mesh-dir", str(mesh_dir)]
@@ -114,7 +105,7 @@ def main():
             print(f"\nInvalid choice '{choice}'. Defaulting to LOD 0...")
             cmd.extend(["--lod", "0"])
     
-    # Execute view_in_napari.py with appropriate arguments
+    # Execute with appropriate arguments
     try:
         print(f"Running command: {' '.join(cmd)}")
         subprocess.run(cmd)


### PR DESCRIPTION
## Summary

This PR simplifies the LOD visualization to address the current need: viewing all LOD levels aligned by default.

## Changes

1. **Simplified `view_all_lods.py` script**:
   - Removed all the complex options and modes
   - Made the default behavior show all LOD levels aligned in the same space
   - Kept the color-coding for easy identification (LOD 0 = Red, LOD 1 = Green, LOD 2 = Blue)
   - Fixed all previous errors with vertex coloring

2. **Simplified the menu in `view_lod_in_napari.py`**:
   - Removed the complex s1/s2 options
   - Added a single 's' option to show all LOD levels aligned

## Benefits

- Simpler, cleaner code
- No syntax errors
- Straightforward functionality: just shows all LOD levels aligned by default
- Fixed all issues with mesh loading and coloring

## Usage

Run the selection utility:
```bash
uv run meshes/visualize-ng-precomputed/view_lod_in_napari.py --mesh-dir precomputed
```

And select option 's' to view all LOD levels aligned.

Or run directly:
```bash
uv run meshes/visualize-ng-precomputed/view_all_lods.py --mesh-dir precomputed
```