### PR TITLE
Fix mesh offset to align with image/labels layers

### DIFF
--- a/meshes/complete_blobs_demo/0.0.1.py
+++ b/meshes/complete_blobs_demo/0.0.1.py
@@ -952,6 +952,10 @@ def main():
         
         trimesh_mesh.fix_normals()
         
+        # Apply a (-1,-1,-1) offset to mesh vertices to correct alignment with image/labels layers
+        print(f"Applying (-1,-1,-1) offset to mesh {mesh_id} to align with image/labels layers")
+        trimesh_mesh.vertices = trimesh_mesh.vertices - np.array([1, 1, 1])
+        
         # Process the mesh with multiple LODs
         mesh_writer.process_mesh(mesh_id, trimesh_mesh, num_lods=3)
         mesh_id += 1

--- a/meshes/view_in_napari/demo.py
+++ b/meshes/view_in_napari/demo.py
@@ -276,6 +276,10 @@ class PrecomputedMeshLoader:
                 
                 mesh.vertices = np.dot(mesh.vertices, rotation.T) + translation
                 
+            # Note: The implementation assumes meshes are already aligned with the image/labels data
+            # If meshes were created with a (-1,-1,-1) offset to align with image/labels, no additional
+            # adjustment is needed here as it's already part of the mesh coordinates
+                
             return mesh
             
         except Exception as e:


### PR DESCRIPTION
This PR fixes the mesh alignment issue by adding a (-1,-1,-1) offset to the mesh vertices to correctly align with the image and labels layers.

## Problem
There is an offset of (1,1,1) between the image/labels layers and the meshes in the current implementation. This causes a visual misalignment when viewing the data.

## Changes

### In `meshes/complete_blobs_demo/0.0.1.py`:
- Added a (-1,-1,-1) offset to mesh vertices during the creation process:
  ```python
  # Apply a (-1,-1,-1) offset to mesh vertices to correct alignment with image/labels layers
  trimesh_mesh.vertices = trimesh_mesh.vertices - np.array([1, 1, 1])
  ```

### In `view_in_napari/demo.py`:
- Added documentation in the mesh loading code to acknowledge the offset correction and clarify the implementation assumptions:
  ```python
  # Note: The implementation assumes meshes are already aligned with the image/labels data
  # If meshes were created with a (-1,-1,-1) offset to align with image/labels, no additional
  # adjustment is needed here as it's already part of the mesh coordinates
  ```

## Testing
The changes have been tested to ensure the meshes align properly with the image and labels data in napari.

## RFC-8 Compliance
These changes maintain compliance with the RFC-8 for mesh support in NGFF as they only modify the vertex coordinates and do not affect the metadata structure or format requirements.