### PR TITLE
Fix numcodecs import error in copick-torch-inspector

### DIFF
--- a/cryoet/copick-torch-inspector/main.py
+++ b/cryoet/copick-torch-inspector/main.py
@@ -19,8 +19,8 @@
 #     "matplotlib",
 #     "fastapi",
 #     "uvicorn",
-#     "zarr<3",
-#     "numcodecs>=0.11.0",
+#     "zarr<2.14.0",
+#     "numcodecs<0.11.0",
 #     "copick-torch @ git+https://github.com/kephale/copick-torch.git",
 #     "copick-server @ git+https://github.com/kephale/copick-server.git"
 # ]


### PR DESCRIPTION
## Description

This PR fixes the ImportError that occurs when trying to import `cbuffer_sizes` from `numcodecs.blosc`.

### Changes made:

1. Pinned the version of `zarr` to be less than 2.14.0 instead of just "zarr<3"
2. Changed `numcodecs>=0.11.0` to `numcodecs<0.11.0` to use a compatible version that doesn't have the naming change for `cbuffer_sizes`

### Error fixed:
```
ImportError: cannot import name 'cbuffer_sizes' from 'numcodecs.blosc' (/flow/.cache/uv/archive-v0/3LGOWXjwsv53RnPKH_XhI/lib/python3.12/site-packages/numcodecs/blosc.cpython-312-x86_64-linux-gnu.so). Did you mean: '_cbuffer_sizes'?
```

This error was caused by newer versions of numcodecs changing the function name to `_cbuffer_sizes`. By downgrading to a version compatible with the current zarr version, both packages will work together properly.