### PR TITLE
Add demo endpoint for Copick project

### DIFF
--- a/cryoet/copick-torch-inspector/main.py
+++ b/cryoet/copick-torch-inspector/main.py
@@ -89,6 +89,7 @@ app.add_middleware(
 # Import from copick-torch
 import copick_torch
 from copick_torch.copick import CopickDataset
+from cryoet_data_portal import client as cryoet_client
 
 @app.get("/tomogram-viz", response_class=HTMLResponse)
 async def visualize_tomograms(
@@ -241,6 +242,236 @@ async def visualize_tomograms(
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error generating visualizations: {str(e)}")
 
+@app.get("/demo", response_class=HTMLResponse)
+async def demo():
+    """Demo endpoint that shows available data in the CryoET project"""
+    # Get project information
+    project_name = root.name
+    project_description = root.description
+    project_version = root.version
+    dataset_ids = getattr(root, 'dataset_ids', [])
+    
+    # Get run information
+    runs = [run.name for run in root.runs]
+    
+    # Get object information
+    objects = [obj.name for obj in root.pickable_objects]
+    
+    # For each run, get available voxel spacings and tomograms
+    run_data = []
+    for run_name in runs:
+        run = root.get_run(run_name)
+        voxel_spacings = [vs.voxel_spacing for vs in run.voxel_spacings]
+        
+        voxel_data = []
+        for vs in voxel_spacings:
+            vs_obj = run.get_voxel_spacing(vs)
+            tomos = [tomo.name for tomo in vs_obj.tomograms]
+            voxel_data.append({
+                'spacing': vs,
+                'tomograms': tomos
+            })
+        
+        run_data.append({
+            'run': run_name,
+            'voxel_spacings': voxel_data
+        })
+    
+    # Get dataset info from CryoET Data Portal if available
+    dataset_info = []
+    try:
+        for dataset_id in dataset_ids:
+            ds_info = cryoet_client.get_dataset(dataset_id)
+            if ds_info:
+                dataset_info.append({
+                    'id': dataset_id,
+                    'title': ds_info.get('title', 'Unknown'),
+                    'authors': ds_info.get('authors', [])
+                })
+    except Exception as e:
+        dataset_info.append({
+            'error': f"Could not fetch dataset info: {str(e)}"
+        })
+    
+    # Build the HTML content
+    html_content = f"""
+    <!DOCTYPE html>
+    <html>
+    <head>
+        <title>Copick Project Demo: {project_name}</title>
+        <style>
+            body {{
+                font-family: Arial, sans-serif;
+                max-width: 1000px;
+                margin: 0 auto;
+                padding: 20px;
+                line-height: 1.6;
+            }}
+            h1, h2, h3 {{
+                color: #2c3e50;
+            }}
+            h1 {{
+                border-bottom: 2px solid #3498db;
+                padding-bottom: 10px;
+            }}
+            .section {{
+                background-color: #f8f9fa;
+                border-left: 4px solid #3498db;
+                padding: 15px;
+                margin: 20px 0;
+                border-radius: 0 5px 5px 0;
+            }}
+            .card {{
+                background-color: white;
+                border-radius: 5px;
+                box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+                padding: 15px;
+                margin: 10px 0;
+            }}
+            .card h4 {{
+                margin-top: 0;
+                color: #3498db;
+            }}
+            code {{
+                background-color: #eee;
+                padding: 2px 5px;
+                border-radius: 3px;
+                font-family: monospace;
+            }}
+            a {{
+                color: #3498db;
+                text-decoration: none;
+            }}
+            a:hover {{
+                text-decoration: underline;
+            }}
+            ul {{
+                padding-left: 20px;
+            }}
+            .tag {{
+                display: inline-block;
+                background-color: #e8f4fc;
+                padding: 2px 8px;
+                border-radius: 3px;
+                margin: 0 5px 5px 0;
+                font-size: 0.9em;
+            }}
+            .demo-link {{
+                background-color: #2ecc71;
+                color: white;
+                padding: 8px 15px;
+                border-radius: 5px;
+                display: inline-block;
+                margin-top: 5px;
+                font-weight: bold;
+            }}
+            .demo-link:hover {{
+                background-color: #27ae60;
+                text-decoration: none;
+            }}
+        </style>
+    </head>
+    <body>
+        <h1>Copick Project Demo: {project_name}</h1>
+        
+        <div class="section">
+            <h2>Project Information</h2>
+            <p><strong>Description:</strong> {project_description}</p>
+            <p><strong>Version:</strong> {project_version}</p>
+        </div>
+        
+        <div class="section">
+            <h2>CryoET Data Portal Datasets</h2>
+            """
+    
+    # Add dataset information
+    if dataset_info:
+        for ds in dataset_info:
+            if 'error' in ds:
+                html_content += f"<p>{ds['error']}</p>"
+            else:
+                html_content += f"""
+                <div class="card">
+                    <h4>Dataset {ds['id']}: {ds['title']}</h4>
+                    <p><strong>Authors:</strong> {', '.join(ds['authors']) if ds['authors'] else 'Unknown'}</p>
+                    <a href="https://cryoetdataportal.cziscience.com/dataset/{ds['id']}" target="_blank" class="demo-link">View on CryoET Data Portal</a>
+                </div>
+                """
+    else:
+        html_content += "<p>No dataset information available</p>"
+    
+    # Add pickable objects section
+    html_content += f"""
+        </div>
+        
+        <div class="section">
+            <h2>Pickable Objects</h2>
+            <p>Objects that can be annotated in this project:</p>
+            <div style="display: flex; flex-wrap: wrap;">
+    """
+    
+    # Add object tags
+    for obj in objects:
+        html_content += f"<span class=\"tag\">{obj}</span>"
+    
+    # Add run information with tomograms
+    html_content += f"""
+            </div>
+        </div>
+        
+        <div class="section">
+            <h2>Runs and Tomograms</h2>
+    """
+    
+    # Add each run's data
+    for run in run_data:
+        html_content += f"""
+            <div class="card">
+                <h4>Run: {run['run']}</h4>
+        """
+        
+        # Add voxel spacings and tomograms
+        for vs_data in run['voxel_spacings']:
+            html_content += f"""
+                <div style="margin-left: 20px;">
+                    <h5>Voxel Spacing: {vs_data['spacing']}</h5>
+                    <ul>
+            """
+            
+            # Add tomogram links
+            for tomo in vs_data['tomograms']:
+                # Create a path that could be used with CopickDataset
+                tomo_path = f"/tmp/copick/{run['run']}/VoxelSpacing{vs_data['spacing']}/{tomo}"
+                html_content += f"""
+                        <li>{tomo} - <a href="/tomogram-viz?dataset_path={tomo_path}" class="demo-link">Visualize</a></li>
+                """
+                
+            html_content += """
+                    </ul>
+                </div>
+            """
+        
+        html_content += """
+            </div>
+        """
+    
+    # Close the HTML document
+    html_content += """
+        </div>
+        
+        <div class="section">
+            <h2>Other Endpoints</h2>
+            <ul>
+                <li><a href="/">Home</a> - Main dashboard</li>
+                <li><a href="/tomogram-viz?dataset_path=/path/to/dataset">Tomogram Visualization</a> - View tomogram samples</li>
+            </ul>
+        </div>
+    </body>
+    </html>
+    """
+    
+    return html_content
+
 @app.get("/", response_class=HTMLResponse)
 async def root():
     """Root endpoint that provides links to available endpoints"""
@@ -285,6 +516,15 @@ async def root():
     <body>
         <h1>Copick Server with Tomogram Visualization</h1>
         
+        <div class="endpoint">
+            <h2>Demo</h2>
+            <p>View a demo of the Copick project data and visualize tomograms directly.</p>
+            <p><strong>Endpoint:</strong> <code>/demo</code></p>
+            <div class="example">
+                <p><strong>Example:</strong> <a href="/demo">/demo</a></p>
+            </div>
+        </div>
+
         <div class="endpoint">
             <h2>Tomogram Visualization</h2>
             <p>Visualizes tomogram samples from a dataset, showing central slices and average projections.</p>


### PR DESCRIPTION
This PR adds a user-friendly demo endpoint that shows data from the Copick project and provides direct links for visualization.

### New Features:

#### `/demo` Endpoint
- Displays comprehensive information about the Copick project
- Shows dataset details from the CryoET Data Portal (using dataset ID 10301)
- Lists all pickable objects in the project (ribosome, atpase, membrane)
- Provides automatically generated links to visualize tomograms from each run

#### Features:
- **Project Overview**: Shows name, description, and version
- **Dataset Information**: Links to CryoET Data Portal for more details
- **Pickable Objects**: Visual tags for each object type
- **Run and Tomogram Explorer**: Hierarchical display of runs → voxel spacings → tomograms
- **Direct Visualization Links**: One-click access to visualize any tomogram

#### Updates to Home Page
- Added a link to the new demo endpoint

### Usage:
1. Start the server as normal
2. Navigate to `/demo` to see the project data
3. Click any "Visualize" link to see tomogram visualizations

This makes it much easier to explore and interact with the Copick project data without needing to know the specific dataset paths or parameters.