### PR TITLE
Fix extract_grid_patches function call syntax error

### DIFF
--- a/cryoet/copick-torch-inspector/main.py
+++ b/cryoet/copick-torch-inspector/main.py
@@ -381,12 +381,11 @@ async def visualize_tomograms(
                 return patches, coordinates
                 
             # Extract patches using our helper function
-            patches, coordinates = extract_grid_patches(tomogram_array, box_size, overlap=0.5, normalize=True)
+            patches, coordinates = extract_grid_patches(
+                tomogram_array, 
                 patch_size=box_size,
                 overlap=0.5,
-                normalize=True,
-                run_index=0,
-                tomo_type='raw'
+                normalize=True
             )
             
             # Use up to batch_size patches


### PR DESCRIPTION
## Issue
There's a syntax error in the call to `extract_grid_patches` in `main.py`. The function is called with mixed positional and keyword arguments, but then there are additional parameters indented below that aren't properly connected to the function call.

## Before
```python
# Extract patches using our helper function
patches, coordinates = extract_grid_patches(tomogram_array, box_size, overlap=0.5, normalize=True)
    patch_size=box_size,
    overlap=0.5,
    normalize=True,
    run_index=0,
    tomo_type='raw'
)
```

## After
```python
# Extract patches using our helper function
patches, coordinates = extract_grid_patches(
    tomogram_array, 
    patch_size=box_size,
    overlap=0.5,
    normalize=True
)
```

## Changes
- Fixed the syntax of the function call to properly use named parameters
- Removed the redundant parameters that weren't actually being used in the function definition
- Formatted the call to be more readable with each parameter on its own line

This fixes the syntax error that would cause runtime errors when trying to extract grid patches from tomograms.