### PR TITLE
Improve CryoET Spliced Volume Renderer

### DIFF
--- a/cryoet/copick-spliced-volume-renderer/README.md
+++ b/cryoet/copick-spliced-volume-renderer/README.md
@@ -25,6 +25,7 @@ uv run https://atrium.kyleharrington.com/cryoet/copick-spliced-volume-renderer/m
 - `--num-examples`: Number of example pairs to create (default: 5)
 - `--structures-per-mask`: Number of structures to extract per mask (default: 1)
 - `--min-structure-size`: Minimum structure size in voxels (default: 500)
+- `--box-size`: Size of the cubic box for extracting structures (default: 48)
 - `--blend-sigma`: Sigma for Gaussian blending at boundaries (default: 2.0)
 - `--output-dir`: Directory to save output files (default: "./spliced_volumes")
 - `--colormap`: Matplotlib colormap for rendering (default: "viridis")

--- a/cryoet/copick-spliced-volume-renderer/main.py
+++ b/cryoet/copick-spliced-volume-renderer/main.py
@@ -517,7 +517,7 @@ def main(args):
         mask_data = mask_zarr["data" if "data" in mask_zarr else "0"][:]
         
         # Extract bounding boxes for structures in the mask
-        bboxes = extract_bounding_boxes(mask_data, min_size=args.min_structure_size)
+        bboxes = extract_bounding_boxes(mask_data, min_size=args.min_structure_size, box_size=48)
         
         if not bboxes:
             logger.warning(f"No structures found in mask {mask_name} larger than {args.min_structure_size} voxels")

--- a/cryoet/copick-spliced-volume-renderer/main.py
+++ b/cryoet/copick-spliced-volume-renderer/main.py
@@ -253,6 +253,18 @@ def splice_volumes(synthetic_tomogram, synthetic_mask, exp_tomogram, bbox_info, 
     # Extract bounding box coordinates
     z_min, y_min, x_min, z_max, y_max, x_max = bbox_info['bbox']
     
+    # Verify dimensions of the mask
+    expected_shape = (z_max - z_min, y_max - y_min, x_max - x_min)
+    mask_shape = bbox_info['region_mask'].shape
+    
+    # If the mask dimensions don't match the expected dimensions, the coordinates might be swapped
+    if mask_shape != expected_shape:
+        logger.warning(f"Mask shape {mask_shape} doesn't match expected shape {expected_shape}. Adjusting coordinates.")
+        # Try to correct by using the mask dimensions to extract the right region
+        z_max = z_min + mask_shape[0]
+        y_max = y_min + mask_shape[1]
+        x_max = x_min + mask_shape[2]
+    
     # Get the masked region from the synthetic tomogram
     synth_region = synthetic_tomogram[z_min:z_max, y_min:y_max, x_min:x_max].copy()
     region_mask = bbox_info['region_mask']

--- a/cryoet/copick-spliced-volume-renderer/main.py
+++ b/cryoet/copick-spliced-volume-renderer/main.py
@@ -671,6 +671,8 @@ if __name__ == "__main__":
                         help="Number of structures to extract per mask")
     parser.add_argument("--min-structure-size", type=int, default=500,
                         help="Minimum structure size in voxels")
+    parser.add_argument("--box-size", type=int, default=48,
+                        help="Size of the cubic box for extracting structures (default: 48)")
     parser.add_argument("--blend-sigma", type=float, default=2.0,
                         help="Sigma for Gaussian blending at boundaries")
     

--- a/cryoet/copick-spliced-volume-renderer/main.py
+++ b/cryoet/copick-spliced-volume-renderer/main.py
@@ -517,7 +517,7 @@ def main(args):
         mask_data = mask_zarr["data" if "data" in mask_zarr else "0"][:]
         
         # Extract bounding boxes for structures in the mask
-        bboxes = extract_bounding_boxes(mask_data, min_size=args.min_structure_size, box_size=48)
+        bboxes = extract_bounding_boxes(mask_data, min_size=args.min_structure_size, box_size=args.box_size)
         
         if not bboxes:
             logger.warning(f"No structures found in mask {mask_name} larger than {args.min_structure_size} voxels")

--- a/cryoet/copick-spliced-volume-renderer/main.py
+++ b/cryoet/copick-spliced-volume-renderer/main.py
@@ -483,6 +483,11 @@ def main(args):
     for mask_name, mask_obj in tqdm(selected_masks, desc="Processing masks"):
         logger.info(f"Processing mask: {mask_name}")
         
+        # Skip membrane segmentation masks
+        if mask_name.lower() == "membrane":
+            logger.info(f"Skipping membrane segmentation mask: {mask_name}")
+            continue
+        
         # Access the mask data
         mask_zarr = zarr.open(mask_obj.zarr(), "r")
         mask_data = mask_zarr["data" if "data" in mask_zarr else "0"][:]

--- a/cryoet/copick-spliced-volume-renderer/main.py
+++ b/cryoet/copick-spliced-volume-renderer/main.py
@@ -397,9 +397,9 @@ def render_comparison_views(original, spliced, metadata, title=None, savepath=No
         if 'mask' in metadata:
             mask = metadata['mask']
             masked_synth = synth_region.copy()
-            masked_synth[~mask] = np.nan  # Make non-mask areas transparent
-            axes[1, 2].imshow(np.max(masked_synth, axis=0), cmap=colormap, vmin=vmin, vmax=vmax)
-            axes[1, 2].set_title('Masked Synthetic (Max Z Proj)')
+            masked_synth[~mask] = 0  # Zero out non-mask areas for sum projection
+            axes[1, 2].imshow(np.sum(masked_synth, axis=0), cmap=colormap)
+            axes[1, 2].set_title('Masked Synthetic (Sum Z Proj)')
         else:
             axes[1, 2].imshow(np.max(synth_region, axis=1), cmap=colormap, vmin=vmin, vmax=vmax)
             axes[1, 2].set_title('Synthetic (Max Y Proj)')


### PR DESCRIPTION
This PR addresses several issues with the CryoET Spliced Volume Renderer:

1. Changed from max z projection to sum z projection for the masked synthetic visualization
2. Fixed potential dimension/coordinate mismatch in synthetic intensity data extraction
3. Added filtering to skip segmentation masks for "membrane" when generating examples
4. Implemented a constant box size of 48^3 regardless of particle size, ensuring the mask/particle is centered within the box

Additional improvements:
- Made box size configurable via a new command-line parameter `--box-size`
- Updated README documentation with the new parameter

These changes should improve the quality and consistency of the generated examples.