### PR TITLE
Fix Neuroglancer mesh info file format

### DIFF
--- a/meshes/complete_blobs_demo/0.0.1.py
+++ b/meshes/complete_blobs_demo/0.0.1.py
@@ -108,21 +108,8 @@ class NeuroglancerMeshWriter:
             "@type": "neuroglancer_multilod_draco",
             "vertex_quantization_bits": self.vertex_quantization_bits,
             "transform": self.transform,
-            "lod_scale_multiplier": self.lod_scale_multiplier,
-            # Add required fields for viewer compatibility
-            "data_type": self.data_type,  # Standard for segmentation data
-            "num_channels": 1,      # Single channel for mesh data
-            "type": "segmentation",  # Important for Neuroglancer to recognize as meshes
-            "scales": [
-                {
-                    "chunk_sizes": [[64, 64, 64]],
-                    "encoding": "compressed_segmentation",
-                    "key": "64_64_64",
-                    "resolution": [1, 1, 1],
-                    "size": [256, 256, 256],  # Match the size of our data
-                    "voxel_offset": [0, 0, 0]
-                }
-            ]
+            "lod_scale_multiplier": self.lod_scale_multiplier
+            # Removed fields that are for precomputed volume metadata, not mesh metadata
         }
         
         with open(self.output_dir / "info", "w") as f:


### PR DESCRIPTION
This PR addresses the issue with Neuroglancer mesh compatibility by removing fields that were incorrectly included in the mesh info file.

The following fields are not supposed to be in the neuroglancer mesh info file and have been removed:
- `data_type`
- `num_channels`
- `type`
- `scales` 

These fields are for a neuroglancer precomputed volume metadata file, not for a mesh metadata file. Removing them should fix the compatibility issue with Neuroglancer.

The change is minimal and only affects the `write_info_file` method in the `NeuroglancerMeshWriter` class.