### PR TITLE
Add Neuroglancer Viewer Demo for Multiscale Meshes

### DIFF
--- a/meshes/view_in_neuroglancer/demo.py
+++ b/meshes/view_in_neuroglancer/demo.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
-# Neuroglancer viewer for multiscale meshes
+# /// script
+# title = "Neuroglancer Precomputed Mesh Viewer"
+# description = "A Python script to view precomputed multiscale mesh data in Neuroglancer"
+# author = "Kyle Harrington"
+# license = "MIT"
+# version = "0.1.0"
+# keywords = ["mesh", "3D", "visualization", "neuroglancer", "precomputed"]
+# documentation = "https://github.com/google/neuroglancer"
+# requires-python = ">=3.8"
+# dependencies = [
+#     "neuroglancer",
+#     "numpy",
+#     "zarr>=3.0.0"
+# ]
+# ///
 
 import argparse
 import neuroglancer

--- a/meshes/view_in_neuroglancer/demo.py
+++ b/meshes/view_in_neuroglancer/demo.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# Neuroglancer viewer for multiscale meshes
+
+import argparse
+import neuroglancer
+import numpy as np
+import os
+import sys
+import zarr
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='View multiscale mesh in Neuroglancer')
+    parser.add_argument('--zarr-path', type=str, required=True,
+                        help='Path to the zarr file containing the data')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    
+    # Ensure the zarr path exists
+    if not os.path.exists(args.zarr_path):
+        print(f"Error: Zarr file {args.zarr_path} does not exist")
+        sys.exit(1)
+    
+    # Set up server for Neuroglancer
+    neuroglancer.set_server_bind_address('127.0.0.1')
+    viewer = neuroglancer.Viewer()
+    
+    # Path where the precomputed mesh data is stored
+    # This assumes that the meshes are stored in the same directory as the zarr file
+    # in a 'precomputed' directory structure
+    mesh_dir = os.path.dirname(os.path.abspath(args.zarr_path))
+    
+    # Load zarr data to extract metadata if needed
+    zarr_data = zarr.open(args.zarr_path, mode='r')
+    
+    # Add the mesh layer using precomputed format
+    with viewer.txn() as s:
+        s.layers['multiscale_mesh'] = neuroglancer.LocalVolume(
+            volume_type='precomputed',
+            mesh=mesh_dir,
+        )
+        
+        # Set default view options
+        s.layers['multiscale_mesh'].visible = True
+        s.layers['multiscale_mesh'].shader = """
+            void main() {
+                emitRGB(vec3(0.8, 0.2, 0.3));
+            }
+        """
+        
+        # Set initial camera position (adjust based on your data)
+        s.navigation.position.voxel_coordinates = [50, 50, 50]
+        s.navigation.zoom_factor = 100
+    
+    print(f"Neuroglancer URL: {viewer.get_viewer_url()}")
+    
+    # Keep the script running
+    print("Press Ctrl+C to exit")
+    input("Press Enter to exit...")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a simple Python-based demo script for viewing multiscale meshes in Neuroglancer, similar to the existing Napari viewer script.

## Features:
- Command-line interface that accepts `--zarr-path` argument
- Uses standard Neuroglancer functionality for precomputed meshes
- Minimal implementation that focuses on viewing the multiscale mesh
- Sets up a basic visualization with customizable shader

## Usage:
```bash
python demo.py --zarr-path output/blob_with_meshes.zarr
```

The script will open a Neuroglancer instance pointing to the mesh data and provide a URL to view in a browser.

Let me know if you need any adjustments or have questions about the implementation.