### PR TITLE
Optimize physarum zarr conversion with circular masking

### DIFF
--- a/laboratory/convert_physarum_to_zarr/main.py
+++ b/laboratory/convert_physarum_to_zarr/main.py
@@ -3,8 +3,8 @@
 # description = "Extract and compress physarum petri dish images from time-series into efficient Zarr format"
 # author = "Kyle Harrington <atrium@kyleharrington.com>"
 # license = "MIT"
-# version = "0.1.0"
-# keywords = ["physarum", "time-series", "zarr", "image-processing", "compression"]
+# version = "0.2.0"
+# keywords = ["physarum", "time-series", "zarr", "image-processing", "compression", "circular-detection"]
 # classifiers = [
 #     "Development Status :: 4 - Beta", 
 #     "Intended Audience :: Science/Research",
@@ -19,7 +19,9 @@
 #     "numpy>=1.24.0",
 #     "pillow>=10.0.0",
 #     "tqdm>=4.65.0",
-#     "typer>=0.9.0"
+#     "typer>=0.9.0",
+#     "opencv-python>=4.8.0",
+#     "scikit-image>=0.21.0"
 # ]
 # ///
 
@@ -33,6 +35,8 @@ import glob
 from tqdm import tqdm
 import typer
 from pathlib import Path
+import cv2
+from skimage import measure
 
 app = typer.Typer()
 
@@ -59,8 +63,88 @@ def detect_dish_layout(image: Image.Image) -> tuple[int, int]:
     else:
         return 3, 2  # 3 rows, 2 columns
 
-def extract_dishes(image: Image.Image, rows: int = 2, cols: int = 3) -> list[np.ndarray]:
-    """Extract individual dishes from the composite image"""
+def detect_circular_dish(image: np.ndarray) -> tuple[int, int, int, np.ndarray]:
+    """
+    Detect the circular petri dish in the image and return its center and radius.
+    Also returns a binary mask of the petri dish area.
+    
+    Args:
+        image: Input image array
+    
+    Returns:
+        tuple: (center_x, center_y, radius, mask)
+    """
+    # Convert to grayscale if needed
+    if len(image.shape) == 3:
+        gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+    else:
+        gray = image.copy()
+    
+    # Apply Gaussian blur to reduce noise
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    
+    # Apply binary thresholding (adjust threshold as needed)
+    _, binary = cv2.threshold(blurred, 100, 255, cv2.THRESH_BINARY_INV)
+    
+    # Find contours in the binary image
+    contours = measure.find_contours(binary, 0.5)
+    
+    # Filter contours by area and circularity
+    dish_contour = None
+    max_area = 0
+    
+    for contour in contours:
+        # Convert to format expected by OpenCV
+        contour_int = np.around(contour).astype(np.int32)
+        
+        # Calculate area and perimeter
+        area = cv2.contourArea(contour_int)
+        perimeter = cv2.arcLength(contour_int, True)
+        
+        # Calculate circularity (perfect circle has circularity = 1)
+        if perimeter > 0:
+            circularity = 4 * np.pi * area / (perimeter ** 2)
+        else:
+            circularity = 0
+            
+        # Check if this could be our dish (large, circular)
+        if area > max_area and circularity > 0.7:  # Adjust threshold as needed
+            dish_contour = contour_int
+            max_area = area
+    
+    if dish_contour is None:
+        # Fallback to using the entire image if no good dish contour is found
+        height, width = gray.shape
+        center_x, center_y = width // 2, height // 2
+        radius = min(width, height) // 2 - 10  # Slightly smaller than half the shortest dimension
+        
+        # Create a circular mask
+        mask = np.zeros_like(gray, dtype=np.uint8)
+        cv2.circle(mask, (center_x, center_y), radius, 255, -1)
+    else:
+        # Find the center and radius of the best fitting circle
+        (center_x, center_y), radius = cv2.minEnclosingCircle(dish_contour)
+        center_x, center_y, radius = int(center_x), int(center_y), int(radius)
+        
+        # Create a circular mask
+        mask = np.zeros_like(gray, dtype=np.uint8)
+        cv2.circle(mask, (center_x, center_y), radius, 255, -1)
+    
+    return center_x, center_y, radius, mask > 0
+
+def extract_dishes(image: Image.Image, rows: int = 2, cols: int = 3, apply_mask: bool = True) -> tuple[list[np.ndarray], list[tuple[int, int, int, np.ndarray]]]:
+    """
+    Extract individual dishes from the composite image and apply circular masks
+    
+    Args:
+        image: Input composite image
+        rows: Number of rows in the dish layout
+        cols: Number of columns in the dish layout
+        apply_mask: Whether to apply circular masking
+        
+    Returns:
+        tuple: (list of dish images, list of dish metadata (center_x, center_y, radius, mask))
+    """
     img_array = np.array(image)
     height, width = img_array.shape[:2]
     
@@ -68,6 +152,8 @@ def extract_dishes(image: Image.Image, rows: int = 2, cols: int = 3) -> list[np.
     dish_width = width // cols
     
     dishes = []
+    dish_metadata = []
+    
     for row in range(rows):
         for col in range(cols):
             top = row * dish_height
@@ -75,17 +161,41 @@ def extract_dishes(image: Image.Image, rows: int = 2, cols: int = 3) -> list[np.
             bottom = top + dish_height
             right = left + dish_width
             
-            dish = img_array[top:bottom, left:right]
-            dishes.append(dish)
+            # Extract the dish region
+            dish = img_array[top:bottom, left:right].copy()
+            
+            if apply_mask:
+                # Detect the circular dish and create a mask
+                cx, cy, radius, mask = detect_circular_dish(dish)
+                
+                # Apply the mask (set background to black)
+                masked_dish = dish.copy()
+                if len(dish.shape) == 3:
+                    # For RGB images
+                    for c in range(dish.shape[2]):
+                        masked_dish[:,:,c] = dish[:,:,c] * mask
+                else:
+                    # For grayscale images
+                    masked_dish = dish * mask
+                
+                dishes.append(masked_dish)
+                dish_metadata.append((cx, cy, radius, mask))
+            else:
+                dishes.append(dish)
+                # Create a default mask (all ones) if not applying masks
+                default_mask = np.ones(dish.shape[:2], dtype=bool)
+                dish_metadata.append((dish_width//2, dish_height//2, min(dish_width, dish_height)//2, default_mask))
     
-    return dishes
+    return dishes, dish_metadata
 
 def create_zarr_dataset(
     input_dir: Path, 
     output_path: Path, 
-    chunk_size: tuple[int, int, int, int, int] = (10, 1, 400, 400, 3)
+    chunk_size: tuple[int, int, int, int, int] = (10, 1, 400, 400, 3),
+    apply_mask: bool = True,
+    mask_background: bool = True
 ) -> zarr.Group:
-    """Create Zarr dataset from physarum images"""
+    """Create Zarr dataset from physarum images with circular masking"""
     
     # Get all png files
     files = sorted(glob.glob(str(input_dir / '*.png')))
@@ -109,7 +219,7 @@ def create_zarr_dataset(
     typer.echo(f"Detected dish layout: {rows}x{cols}")
     
     # Extract sample to get dimensions
-    sample_dishes = extract_dishes(first_image, rows, cols)
+    sample_dishes, dish_metadata = extract_dishes(first_image, rows, cols, apply_mask)
     dish_shape = sample_dishes[0].shape
     typer.echo(f"Each dish shape: {dish_shape}")
     
@@ -119,6 +229,7 @@ def create_zarr_dataset(
     
     typer.echo(f"Creating Zarr dataset with shape: {zarr_shape}")
     typer.echo(f"Chunk size: {chunk_size}")
+    typer.echo(f"Applying circular masking: {apply_mask}")
     
     # Create the main dataset
     zarr_store = zarr.DirectoryStore(str(output_path))
@@ -130,15 +241,17 @@ def create_zarr_dataset(
         shape=zarr_shape,
         chunks=chunk_size,
         dtype=np.uint8,
-        compressor=zarr.Blosc(cname='zstd', clevel=3, shuffle=2)
+        compressor=zarr.Blosc(cname='zstd', clevel=5, shuffle=2)  # Increased compression level
     )
     
     # Add metadata
+    experiment_name = os.path.basename(output_path).split('.')[0]
     data.attrs['description'] = 'Physarum polycephalum time-series imaging data'
-    data.attrs['experiment'] = 'experiment_010'
+    data.attrs['experiment'] = experiment_name
     data.attrs['dimensions'] = ['time', 'dish', 'height', 'width', 'channels']
     data.attrs['dish_layout'] = f'{rows}x{cols}'
     data.attrs['created_at'] = datetime.now().isoformat()
+    data.attrs['circular_masking_applied'] = apply_mask
     
     # Create timestamps array
     timestamp_array = root.create_dataset(
@@ -153,7 +266,7 @@ def create_zarr_dataset(
     for i, file in enumerate(tqdm(files)):
         try:
             img = Image.open(file)
-            dishes = extract_dishes(img, rows, cols)
+            dishes, _ = extract_dishes(img, rows, cols, apply_mask)
             
             for j, dish in enumerate(dishes):
                 data[i, j] = dish
@@ -163,6 +276,10 @@ def create_zarr_dataset(
     
     # Add dish metadata
     dish_metadata = root.create_group('dish_metadata')
+    
+    # Get first image dish metadata for storing masks
+    _, first_dish_metadata = extract_dishes(first_image, rows, cols, apply_mask)
+    
     for i in range(total_dishes):
         row = i // cols
         col = i % cols
@@ -170,9 +287,29 @@ def create_zarr_dataset(
         dish_meta.attrs['row'] = row
         dish_meta.attrs['column'] = col
         dish_meta.attrs['position'] = f'row_{row}_col_{col}'
+        
+        # Add circular dish metadata
+        cx, cy, radius, mask = first_dish_metadata[i]
+        dish_meta.attrs['center_x'] = cx
+        dish_meta.attrs['center_y'] = cy
+        dish_meta.attrs['radius'] = radius
+        
+        # Store binary mask (compressed)
+        dish_meta.create_dataset(
+            'mask',
+            data=mask.astype(np.uint8),
+            compressor=zarr.Blosc(cname='zstd', clevel=9, shuffle=2)
+        )
+    
+    # Calculate compression efficiency
+    original_size = sum(os.path.getsize(f) for f in files)
+    compressed_size = get_dir_size(output_path)
+    compression_ratio = original_size / max(compressed_size, 1)  # Avoid division by zero
     
     typer.echo(f"Dataset created successfully at: {output_path}")
-    typer.echo(f"Total size on disk: {get_dir_size(output_path) / (1024**3):.2f} GB")
+    typer.echo(f"Original size: {original_size / (1024**3):.2f} GB")
+    typer.echo(f"Compressed size: {compressed_size / (1024**3):.2f} GB")
+    typer.echo(f"Compression ratio: {compression_ratio:.2f}x")
     
     return root
 
@@ -206,15 +343,26 @@ def verify_zarr_dataset(zarr_path: Path) -> bool:
     sample_timestamp = root.timestamps[0]
     typer.echo(f"First timestamp: {sample_timestamp}")
     
+    # Check for masks
+    if 'dish_metadata' in root:
+        has_masks = False
+        for dish_name in root.dish_metadata:
+            if 'mask' in root.dish_metadata[dish_name]:
+                has_masks = True
+                break
+        typer.echo(f"Contains dish masks: {has_masks}")
+    
     return True
 
 @app.command()
 def convert(
     input_dir: str = typer.Argument(..., help="Directory containing physarum PNG images"),
     output_path: str = typer.Argument(..., help="Output path for Zarr dataset"),
-    chunk_size: str = typer.Option("10,1,400,400,3", "--chunk-size", "-c", help="Chunk size as comma-separated values")
+    chunk_size: str = typer.Option("10,1,400,400,3", "--chunk-size", "-c", help="Chunk size as comma-separated values"),
+    apply_mask: bool = typer.Option(True, "--mask/--no-mask", help="Apply circular dish masking"),
+    mask_background: bool = typer.Option(True, "--mask-background/--keep-background", help="Set background outside dish to black")
 ):
-    """Convert physarum time-series PNG images to optimized Zarr format"""
+    """Convert physarum time-series PNG images to optimized Zarr format with circular masking"""
     input_path = Path(input_dir)
     output_zarr = Path(output_path)
     
@@ -228,7 +376,9 @@ def convert(
     zarr_dataset = create_zarr_dataset(
         input_dir=input_path,
         output_path=output_zarr,
-        chunk_size=chunk_tuple
+        chunk_size=chunk_tuple,
+        apply_mask=apply_mask,
+        mask_background=mask_background
     )
     
     # Verify the dataset
@@ -245,9 +395,11 @@ def example():
     typer.echo("\nExample usage of the Zarr dataset:")
     typer.echo("""
     import zarr
+    import matplotlib.pyplot as plt
+    import numpy as np
     
     # Load the dataset
-    root = zarr.open("./physarum_experiment_010.zarr", mode='r')
+    root = zarr.open("./physarum_experiment.zarr", mode='r')
     
     # Access specific data
     first_dish_all_times = root.images[:, 0]  # All timepoints for dish 0
@@ -257,6 +409,33 @@ def example():
     # Access metadata
     print(root.images.attrs['dish_layout'])
     print(root.timestamps[0])  # First timestamp
+    
+    # Load mask for a specific dish
+    dish_id = 0
+    mask = root.dish_metadata[f'dish_{dish_id}'].mask[:]
+    
+    # Visualize an image with its mask
+    plt.figure(figsize=(12, 4))
+    
+    plt.subplot(1, 3, 1)
+    plt.imshow(root.images[0, dish_id])
+    plt.title("Original dish image")
+    
+    plt.subplot(1, 3, 2)
+    plt.imshow(mask, cmap='gray')
+    plt.title("Dish mask")
+    
+    plt.subplot(1, 3, 3)
+    # Apply mask to show what's being tracked
+    img = root.images[0, dish_id].copy()
+    masked_img = img.copy()
+    for c in range(img.shape[2]):
+        masked_img[:,:,c] = img[:,:,c] * mask
+    plt.imshow(masked_img)
+    plt.title("Masked dish image")
+    
+    plt.tight_layout()
+    plt.show()
     """)
 
 if __name__ == "__main__":

--- a/laboratory/visualize_dish_detection/main.py
+++ b/laboratory/visualize_dish_detection/main.py
@@ -1,0 +1,252 @@
+# /// script
+# title = "Visualize Physarum Petri Dish Detection"
+# description = "Demonstration tool for visualizing the circular dish detection used in physarum zarr conversion"
+# author = "Kyle Harrington <atrium@kyleharrington.com>"
+# license = "MIT"
+# version = "0.1.0"
+# keywords = ["physarum", "image-processing", "circular-detection", "visualization"]
+# classifiers = [
+#     "Development Status :: 4 - Beta", 
+#     "Intended Audience :: Science/Research",
+#     "License :: OSI Approved :: MIT License",
+#     "Programming Language :: Python :: 3.12",
+#     "Topic :: Scientific/Engineering :: Bio-Informatics",
+#     "Topic :: Scientific/Engineering :: Image Processing"
+# ]
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy>=1.24.0",
+#     "pillow>=10.0.0",
+#     "typer>=0.9.0",
+#     "opencv-python>=4.8.0",
+#     "scikit-image>=0.21.0",
+#     "matplotlib>=3.7.0"
+# ]
+# ///
+
+import os
+import numpy as np
+from PIL import Image
+import typer
+from pathlib import Path
+import cv2
+from skimage import measure
+import matplotlib.pyplot as plt
+from matplotlib.patches import Circle
+
+app = typer.Typer()
+
+def detect_dish_layout(image: Image.Image) -> tuple[int, int]:
+    """
+    Analyze image to determine dish layout (2x3 or 3x2)
+    This should be customized based on your specific setup
+    """
+    height, width = image.size
+    if height > width:  # Taller than wide
+        return 2, 3  # 2 rows, 3 columns
+    else:
+        return 3, 2  # 3 rows, 2 columns
+
+def detect_circular_dish(image: np.ndarray) -> tuple[int, int, int, np.ndarray]:
+    """
+    Detect the circular petri dish in the image and return its center and radius.
+    Also returns a binary mask of the petri dish area.
+    
+    Args:
+        image: Input image array
+    
+    Returns:
+        tuple: (center_x, center_y, radius, mask)
+    """
+    # Convert to grayscale if needed
+    if len(image.shape) == 3:
+        gray = cv2.cvtColor(image, cv2.COLOR_RGB2GRAY)
+    else:
+        gray = image.copy()
+    
+    # Apply Gaussian blur to reduce noise
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    
+    # Apply binary thresholding (adjust threshold as needed)
+    _, binary = cv2.threshold(blurred, 100, 255, cv2.THRESH_BINARY_INV)
+    
+    # Find contours in the binary image
+    contours = measure.find_contours(binary, 0.5)
+    
+    # Filter contours by area and circularity
+    dish_contour = None
+    max_area = 0
+    
+    for contour in contours:
+        # Convert to format expected by OpenCV
+        contour_int = np.around(contour).astype(np.int32)
+        
+        # Calculate area and perimeter
+        area = cv2.contourArea(contour_int)
+        perimeter = cv2.arcLength(contour_int, True)
+        
+        # Calculate circularity (perfect circle has circularity = 1)
+        if perimeter > 0:
+            circularity = 4 * np.pi * area / (perimeter ** 2)
+        else:
+            circularity = 0
+            
+        # Check if this could be our dish (large, circular)
+        if area > max_area and circularity > 0.7:  # Adjust threshold as needed
+            dish_contour = contour_int
+            max_area = area
+    
+    if dish_contour is None:
+        # Fallback to using the entire image if no good dish contour is found
+        height, width = gray.shape
+        center_x, center_y = width // 2, height // 2
+        radius = min(width, height) // 2 - 10  # Slightly smaller than half the shortest dimension
+        
+        # Create a circular mask
+        mask = np.zeros_like(gray, dtype=np.uint8)
+        cv2.circle(mask, (center_x, center_y), radius, 255, -1)
+    else:
+        # Find the center and radius of the best fitting circle
+        (center_x, center_y), radius = cv2.minEnclosingCircle(dish_contour)
+        center_x, center_y, radius = int(center_x), int(center_y), int(radius)
+        
+        # Create a circular mask
+        mask = np.zeros_like(gray, dtype=np.uint8)
+        cv2.circle(mask, (center_x, center_y), radius, 255, -1)
+    
+    return center_x, center_y, radius, mask > 0
+
+def extract_dishes(image: Image.Image, rows: int = 2, cols: int = 3) -> tuple[list[np.ndarray], list[tuple[int, int, int, np.ndarray]]]:
+    """Extract individual dishes from the composite image"""
+    img_array = np.array(image)
+    height, width = img_array.shape[:2]
+    
+    dish_height = height // rows
+    dish_width = width // cols
+    
+    dishes = []
+    dish_metadata = []
+    
+    for row in range(rows):
+        for col in range(cols):
+            top = row * dish_height
+            left = col * dish_width
+            bottom = top + dish_height
+            right = left + dish_width
+            
+            # Extract the dish region
+            dish = img_array[top:bottom, left:right].copy()
+            
+            # Detect the circular dish and create a mask
+            cx, cy, radius, mask = detect_circular_dish(dish)
+            
+            dishes.append(dish)
+            dish_metadata.append((cx, cy, radius, mask))
+    
+    return dishes, dish_metadata
+
+@app.command()
+def visualize(
+    image_path: str = typer.Argument(..., help="Path to input image with petri dishes"),
+    output_dir: str = typer.Option(None, "--output-dir", "-o", help="Directory to save visualization (optional)"),
+    show_plots: bool = typer.Option(True, "--show/--no-show", help="Show visualization plots")
+):
+    """Visualize the dish detection and masking process"""
+    # Load image
+    image = Image.open(image_path)
+    typer.echo(f"Loaded image with size: {image.size}")
+    
+    # Detect dish layout
+    rows, cols = detect_dish_layout(image)
+    typer.echo(f"Detected dish layout: {rows}x{cols}")
+    
+    # Extract dishes and detect circles
+    dishes, dish_metadata = extract_dishes(image, rows, cols)
+    
+    # Create output directory if specified
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+    
+    # Create a figure to visualize the whole process
+    plt.figure(figsize=(18, 10))
+    
+    # Plot composite image with grid
+    plt.subplot(2, 3, 1)
+    plt.imshow(np.array(image))
+    plt.title("Original Image with Dish Grid")
+    
+    # Draw grid lines
+    height, width = np.array(image).shape[:2]
+    dish_height = height // rows
+    dish_width = width // cols
+    
+    for i in range(1, rows):
+        plt.axhline(y=i * dish_height, color='r', linestyle='--')
+    
+    for i in range(1, cols):
+        plt.axvline(x=i * dish_width, color='r', linestyle='--')
+    
+    # Plot each dish with detected circle
+    dish_idx = 1
+    for row in range(rows):
+        for col in range(cols):
+            dish_idx += 1
+            if dish_idx <= 6:  # Only show first 5 dishes to avoid overflow
+                plt.subplot(2, 3, dish_idx)
+                
+                dish = dishes[row * cols + col]
+                cx, cy, radius, mask = dish_metadata[row * cols + col]
+                
+                # Display the dish
+                plt.imshow(dish)
+                plt.title(f"Dish {row * cols + col + 1}")
+                
+                # Add circle overlay
+                circle = Circle((cx, cy), radius, fill=False, edgecolor='red', linewidth=2)
+                plt.gca().add_patch(circle)
+    
+    plt.tight_layout()
+    
+    # Another figure to show the masking effect
+    plt.figure(figsize=(18, 10))
+    
+    for i, (dish, (cx, cy, radius, mask)) in enumerate(zip(dishes, dish_metadata)):
+        if i >= 6:  # Only show first 6 dishes
+            break
+            
+        plt.subplot(2, 3, i+1)
+        
+        # Create masked version
+        masked_dish = dish.copy()
+        if len(dish.shape) == 3:
+            # For RGB images
+            for c in range(dish.shape[2]):
+                masked_dish[:,:,c] = dish[:,:,c] * mask
+        else:
+            # For grayscale images
+            masked_dish = dish * mask
+        
+        # Side by side comparison
+        comparison = np.hstack([dish, masked_dish])
+        plt.imshow(comparison)
+        plt.title(f"Dish {i+1}: Original vs Masked")
+        plt.axis('off')
+    
+    plt.tight_layout()
+    
+    # Save figures if output directory is specified
+    if output_dir:
+        plt.figure(1)
+        plt.savefig(os.path.join(output_dir, "dish_detection.png"), dpi=150)
+        plt.figure(2)
+        plt.savefig(os.path.join(output_dir, "dish_masking.png"), dpi=150)
+        typer.echo(f"Saved visualization to {output_dir}")
+    
+    # Show plots if requested
+    if show_plots:
+        plt.show()
+    else:
+        plt.close('all')
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
## Circular Masking for Physarum Zarr Conversion

This PR adds circular petri dish detection and masking capabilities to the physarum zarr conversion tool, addressing the request to make the files smaller by only storing the relevant regions inside the petri dishes.

### Changes:

1. **Enhanced `convert_physarum_to_zarr` script:**
   - Added automatic circular dish detection using OpenCV and scikit-image
   - Implemented circular masking to set background pixels to black (zero)
   - Stored dish masks in the zarr metadata for future reference
   - Improved compression settings for smaller file sizes
   - Added command-line options to toggle masking behavior

2. **New visualization tool:**
   - Added `visualize_dish_detection` script for demonstrating and debugging the circular dish detection
   - Provides visual feedback on how well the algorithm works with specific images

### Technical Details:

- The circular detection algorithm uses contour detection, filtering by circularity and area
- Fallback mechanism if no good circular contour is found
- Masks are stored in compressed format for reference
- Compression is improved both by:
  1. Setting background pixels to zero (more compressible)
  2. Using a higher compression level

### Usage:

```bash
# Convert with circular masking (default)
uv run https://atrium.kyleharrington.com/laboratory/convert_physarum_to_zarr/main.py convert /path/to/input/ /path/to/output.zarr

# Convert without masking if needed
uv run https://atrium.kyleharrington.com/laboratory/convert_physarum_to_zarr/main.py convert /path/to/input/ /path/to/output.zarr --no-mask

# Visualize the dish detection on a sample image
uv run https://atrium.kyleharrington.com/laboratory/visualize_dish_detection/main.py visualize /path/to/sample_image.png --output-dir /path/to/save/visualization
```

This should help make the zarr files significantly smaller while preserving all the important data for the experiments.