### PR TITLE
Add 'Share on Bluesky' button to script pages

### DIFF
--- a/atrium/update/0.0.1.py
+++ b/atrium/update/0.0.1.py
@@ -1112,6 +1112,11 @@ SOLUTION_TEMPLATE = """
                     External Source
                 </a>
             {% endif %}
+            
+            <a href="https://bsky.app/intent/compose?text=Check%20out%20this%20Python%20script%20on%20Atrium:%20{{ title | urlencode }}%20%23atrium%20%23python{% if cover_image %}%20{{ cover_image | urlencode }}{% endif %}%20{{ site_config.base_url }}/{{ link }}" target="_blank" class="link-item">
+                <i class="fas fa-share-alt"></i>
+                Share on Bluesky
+            </a>
         </div>
     </main>
 


### PR DESCRIPTION
This PR adds a 'Share on Bluesky' link to all script pages in the Atrium collection.

The changes:
- Added a share button with the proper Bluesky intent URL format
- Includes #atrium and #python hashtags in the share content
- Includes the cover image URL when available
- Added to the links section at the bottom of each script page

This is a minimal change that just adds the functionality without modifying the existing design.