### PR TITLE
Fix Bluesky share link for cleaner message format

### DIFF
--- a/atrium/update/0.0.1.py
+++ b/atrium/update/0.0.1.py
@@ -1113,7 +1113,7 @@ SOLUTION_TEMPLATE = """
                 </a>
             {% endif %}
             
-            <a href="https://bsky.app/intent/compose?text=Check%20out%20this%20Python%20script%20on%20Atrium:%20{{ title | urlencode }}%20%23atrium%20%23python{% if cover_image %}%20{{ cover_image | urlencode }}{% endif %}%20{{ site_config.base_url }}/{{ link }}" target="_blank" class="link-item">
+            <a href="https://bsky.app/intent/compose?text=Check%20out%20this%20Python%20script%20on%20Atrium:%20{{ title | urlencode }}%20%23atrium%20%23python%20{{ site_config.base_url }}/{{ link }}" target="_blank" class="link-item">
                 <i class="fas fa-share-alt"></i>
                 Share on Bluesky
             </a>


### PR DESCRIPTION
This PR fixes the Bluesky share link to create a cleaner message.

The change:
- Removed the cover image URL from the share text content
- Keeps just the title, hashtags (#atrium #python), and link to the script page

This creates a much more readable and concise share message on Bluesky.

Example of new format:
"Check out this Python script on Atrium: Mandelbrot Set #atrium #python https://atrium.kyleharrington.com/fractals/napari-mandelbrot"